### PR TITLE
Add codecov configuration file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  round: nearest
+  range: 0..100
+  precision: 3
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+        if_ci_failed: error


### PR DESCRIPTION
This PR adds a configuration file for [code cov](https://about.codecov.io/). The configuration adds the following parameters to the coverage
1. The coverage is rounded to the nearest value
2.  It has a range between 0-100 and would be displayed with a 3 precision value
3. Adds a threshold of 1% coverage drop in a PR.