### PR TITLE
Remove if condition from documentation generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,6 @@ jobs:
 
   pages:
     needs: build
-    if: github.event.pull_request.merged == true
     name: Generate documentation and upload it on pages
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR removes the if the condition from the documentation build in CI. This ensures that the documentation is build when a PR is created