### PR TITLE
Use metadata for feedback

### DIFF
--- a/sail_on_client/protocol/ond_test.py
+++ b/sail_on_client/protocol/ond_test.py
@@ -88,8 +88,10 @@ class ONDTest(VisualTest):
         """
         log.info("Creating Feedback object")
         if feedback_max_ids == 0:
-            log.warn("""feedback_max_ids was missing from metadata, thus setting
-                        the feedback budget to 0""")
+            log.warn(
+                """feedback_max_ids was missing from metadata, thus setting
+                        the feedback budget to 0"""
+            )
         feedback_params = {
             "first_budget": feedback_max_ids,
             "income_per_batch": feedback_max_ids,
@@ -134,8 +136,7 @@ class ONDTest(VisualTest):
         redlight_instance = metadata.get("red_light", "")
         feedback_max_ids = metadata.get("feedback_max_ids", 0)
         # Initialize feedback object for the domains
-        feedback_instance = self._create_feedback_instance(test_id,
-                                                           feedback_max_ids)
+        feedback_instance = self._create_feedback_instance(test_id, feedback_max_ids)
 
         # Initialize algorithm
         algorithm_instance = self.algorithm_attributes.instance

--- a/tests/test_ond_test.py
+++ b/tests/test_ond_test.py
@@ -126,13 +126,12 @@ def test_call(ond_harness_instance, ond_algorithm_instance):
         None
     """
     test_ids = ["OND.10.90001.2100554"]
-    feedback_params = {"first_budget": 4, "income_per_batch": 4, "maximum_budget": 4}
     algorithm_attribute = create_algorithm_attribute(
         ALGORITHM_NAME,
         ond_algorithm_instance,
         False,
         False,
-        {"feedback_params": feedback_params},
+        {},
         "",
         test_ids,
     )
@@ -173,13 +172,12 @@ def test_call_with_features(ond_harness_instance, ond_algorithm_instance):
         None
     """
     test_ids = ["OND.10.90001.2100554"]
-    feedback_params = {"first_budget": 4, "income_per_batch": 4, "maximum_budget": 4}
     algorithm_attribute = create_algorithm_attribute(
         ALGORITHM_NAME,
         ond_algorithm_instance,
         False,
         False,
-        {"feedback_params": feedback_params},
+        {},
         "",
         test_ids,
     )

--- a/tests/test_ond_test.py
+++ b/tests/test_ond_test.py
@@ -127,13 +127,7 @@ def test_call(ond_harness_instance, ond_algorithm_instance):
     """
     test_ids = ["OND.10.90001.2100554"]
     algorithm_attribute = create_algorithm_attribute(
-        ALGORITHM_NAME,
-        ond_algorithm_instance,
-        False,
-        False,
-        {},
-        "",
-        test_ids,
+        ALGORITHM_NAME, ond_algorithm_instance, False, False, {}, "", test_ids,
     )
     session_id = ond_harness_instance.session_request(
         test_ids,
@@ -173,13 +167,7 @@ def test_call_with_features(ond_harness_instance, ond_algorithm_instance):
     """
     test_ids = ["OND.10.90001.2100554"]
     algorithm_attribute = create_algorithm_attribute(
-        ALGORITHM_NAME,
-        ond_algorithm_instance,
-        False,
-        False,
-        {},
-        "",
-        test_ids,
+        ALGORITHM_NAME, ond_algorithm_instance, False, False, {}, "", test_ids,
     )
     session_id = ond_harness_instance.session_request(
         test_ids,


### PR DESCRIPTION
This PR removes the dependence on algorithm params for getting feedback parameters. It creates the feedback object by getting feedback parameters from metadata.