### PR TITLE
Remove __version__

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ Please refer to [version](https://python-poetry.org/docs/cli/#version) for more 
 Thus to publish sail-on-client on pypi use the following commands
 
 1. Bump the version in pyproject.toml using `poetry version <version_rule>`.
-2. Update `__version__` with the new version in `sail_on_client/__init__.py`.
-3. Use poetry version --short to determine the version that would be used in the tag.
-4. Generate and push the tag using
+2. Use poetry version --short to determine the version that would be used in the tag.
+3. Generate and push the tag using
    ```
      git tag <package-version>
      git push origin --tags

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,10 @@ import sys
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
 
-from sail_on_client import __version__
+try:
+    from importlib.metadata import version  # type:ignore
+except ModuleNotFoundError:
+    from importlib_metadata import version  # type: ignore
 
 # -- Project information -----------------------------------------------------
 
@@ -27,8 +30,8 @@ author = "Kitware INC."
 
 # TODO: Get the version from the package
 # The full version, including alpha/beta/rc tags
-release = __version__
-version = __version__
+release = version("sail-on-client")
+version = version("sail-on-client")
 
 # -- General configuration ---------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sail-on-client"
-version = "0.26.0"
+version = "0.27.0"
 description = "Client and Protocols for DARPA sail-on"
 authors = ["Ameya Shringi <ameya.shringi@kitware.com>",
            "Christopher Funk <christopher.funk@kitware.com>",

--- a/sail_on_client/__init__.py
+++ b/sail_on_client/__init__.py
@@ -1,3 +1,1 @@
 """Sail-on client package."""
-
-__version__ = "0.26.0"


### PR DESCRIPTION
This PR removes __version__ string from sail-on-client/__init__.py. Python provides helper functions under `importlib` to determine the version of a package, thus maintaining an additional __version__ is redundant. 