### PR TITLE
Remove get_classification_score_feedback from documentation

### DIFF
--- a/docs/source/harness/harness_api.rst
+++ b/docs/source/harness/harness_api.rst
@@ -49,8 +49,6 @@ File Provider Utility Methods
 
 .. autofunction:: sail_on_client.harness.file_provider_fn.get_detection_feedback
 
-.. autofunction:: sail_on_client.harness.file_provider_fn.get_classification_score_feedback
-
 .. autofunction:: sail_on_client.harness.file_provider_fn.get_characterization_feedback
 
 .. autofunction:: sail_on_client.harness.file_provider_fn.get_levenshtein_feedback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sail-on-client"
-version = "0.30.1"
+version = "0.30.2"
 description = "Client and Protocols for DARPA sail-on"
 authors = ["Ameya Shringi <ameya.shringi@kitware.com>",
            "Christopher Funk <christopher.funk@kitware.com>",


### PR DESCRIPTION
This PR remove `get_classification_score_feedback` from the documentation to fix documentation generation.